### PR TITLE
Added test case to automate application list sorting

### DIFF
--- a/mta/entities/report.py
+++ b/mta/entities/report.py
@@ -21,6 +21,8 @@ class AllApplicationsView(BaseLoggedInPage):
     filter_selector = DropdownMenu(locator='.//span[@class="filter-by"]/parent::button/parent::div')
     application_table = ApplicationList()
 
+    sort_selector = DropdownMenu(locator='.//span[@id="sort-by"]/parent::button/parent::div')
+
     def clear_filters(self):
         if self.clear.is_displayed:
             self.clear.click()
@@ -34,6 +36,12 @@ class AllApplicationsView(BaseLoggedInPage):
         if filter_type:
             self.filter_selector.item_select(filter_type)
         self.filter_application.fill(search_value)
+    
+    def sort_by(self, sort_criteria="Name"):
+        """
+        Select the sort criteria among Name and Story Points to sort applications list
+        """
+        self.sort_selector.item_select(sort_criteria)
 
     @property
     def is_displayed(self):

--- a/mta/entities/report.py
+++ b/mta/entities/report.py
@@ -36,7 +36,7 @@ class AllApplicationsView(BaseLoggedInPage):
         if filter_type:
             self.filter_selector.item_select(filter_type)
         self.filter_application.fill(search_value)
-    
+
     def sort_by(self, sort_criteria="Name"):
         """
         Select the sort criteria among Name and Story Points to sort applications list

--- a/mta/tests/test_report.py
+++ b/mta/tests/test_report.py
@@ -1,6 +1,7 @@
 from mta.entities.analysis_results import AnalysisResultsView
 from mta.entities.report import AllApplicationsView
 
+
 def test_send_feedback(create_minimal_project):
     """Test send feedback
 
@@ -56,6 +57,7 @@ def test_filter_application_list(create_project_with_two_apps):
     apps_list = view.application_table.get_applications_list
     assert "acmeair-webapp-1.0-SNAPSHOT.war" in apps_list[:-1]
 
+
 def test_sort_applications(create_project):
     """Test Sorting of applications
 
@@ -82,6 +84,10 @@ def test_sort_applications(create_project):
     app_list_by_name = view.application_table.get_applications_list
     assert app_list_by_name[:-1] == sorted(app_list_by_name[:-1])
     view.sort_by("Story Points")
-    expected_app_list_by_story_points = ["cadmium-war-0.1.0.war", "acmeair-webapp-1.0-SNAPSHOT.war", "bw-note-ear-4.0.0.ear"]
+    expected_app_list_by_story_points = [
+        "cadmium-war-0.1.0.war",
+        "acmeair-webapp-1.0-SNAPSHOT.war",
+        "bw-note-ear-4.0.0.ear"
+    ]
     app_list_by_story_points = view.application_table.get_applications_list
     assert app_list_by_story_points[:-1] == expected_app_list_by_story_points

--- a/mta/tests/test_report.py
+++ b/mta/tests/test_report.py
@@ -58,7 +58,7 @@ def test_filter_application_list(create_project_with_two_apps):
     assert "acmeair-webapp-1.0-SNAPSHOT.war" in apps_list[:-1]
 
 
-def test_sort_applications(create_project):
+def test_sort_application_list(create_project):
     """Test Sorting of applications
 
     Polarion:

--- a/mta/tests/test_report.py
+++ b/mta/tests/test_report.py
@@ -1,7 +1,6 @@
 from mta.entities.analysis_results import AnalysisResultsView
 from mta.entities.report import AllApplicationsView
 
-
 def test_send_feedback(create_minimal_project):
     """Test send feedback
 
@@ -56,3 +55,33 @@ def test_filter_application_list(create_project_with_two_apps):
     view.search("JTA", "Tag")
     apps_list = view.application_table.get_applications_list
     assert "acmeair-webapp-1.0-SNAPSHOT.war" in apps_list[:-1]
+
+def test_sort_applications(create_project):
+    """Test Sorting of applications
+
+    Polarion:
+        assignee: nsrivast
+        initialEstimate: 1/12h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        casecomponent: WebConsole
+        testSteps:
+            1. Create project and run analysis
+            2. Click on report action to see detailed report and select tab - All Applications
+            3. Sort applications by name or story points
+        expectedResults:
+            1. It should sort applications as per selected criteria (name or story points)
+    """
+    project, project_collection = create_project
+    view = project_collection.create_view(AnalysisResultsView)
+    view.wait_displayed()
+    view.analysis_results.show_report()
+    view = project_collection.create_view(AllApplicationsView)
+    view.sort_by("Name")
+    app_list_by_name = view.application_table.get_applications_list
+    assert app_list_by_name[:-1] == sorted(app_list_by_name[:-1])
+    view.sort_by("Story Points")
+    expected_app_list_by_story_points = ["cadmium-war-0.1.0.war", "acmeair-webapp-1.0-SNAPSHOT.war", "bw-note-ear-4.0.0.ear"]
+    app_list_by_story_points = view.application_table.get_applications_list
+    assert app_list_by_story_points[:-1] == expected_app_list_by_story_points

--- a/mta/tests/test_report.py
+++ b/mta/tests/test_report.py
@@ -87,7 +87,7 @@ def test_sort_applications(create_project):
     expected_app_list_by_story_points = [
         "cadmium-war-0.1.0.war",
         "acmeair-webapp-1.0-SNAPSHOT.war",
-        "bw-note-ear-4.0.0.ear"
+        "bw-note-ear-4.0.0.ear",
     ]
     app_list_by_story_points = view.application_table.get_applications_list
     assert app_list_by_story_points[:-1] == expected_app_list_by_story_points

--- a/mta/widgetastic/__init__.py
+++ b/mta/widgetastic/__init__.py
@@ -36,6 +36,7 @@ class DropdownMenu(Dropdown):
     ROOT = ParametrizedLocator("{@locator}")
     BUTTON_LOCATOR = (
         ".//span[@class='filter-by']/parent::button | "
+        ".//span[@id='sort-by']/parent::button | "
         ".//button[contains(@class, 'pf-c-context-selector__toggle')]"
     )
     ITEMS_LOCATOR = ".//ul/li/button | .//ul/li/a"


### PR DESCRIPTION
Test case for sorting applications list by name and story points. 

1. Create project with app list - [
            "acmeair-webapp-1.0-SNAPSHOT.war",
            "cadmium-war-0.1.0.war",
            "bw-note-ear-4.0.0.ear",
        ]
2. Run analysis
3. Open applications list page
4. Sort by name (arranges apps alphabetically)
5. Sort by story points (arranges in increasing order of story points)
6. Modified DropdownMenu Widget for selecting sort dropdown
7. Added new method to sort based on sort criteria

