### PR TITLE
RFR: Automated global labels configuration test cases

### DIFF
--- a/entry_points.txt
+++ b/entry_points.txt
@@ -8,4 +8,4 @@ mta = mta.scripting.cli:cli
 [mta.application_collections]
 base = mta.entities:BaseWebUICollection
 projects = mta.entities.projects:ProjectCollection
-globalconfigurations = mta.entities.rules_configuration:GlobalRulesCollection
+globalconfigurations = mta.entities.rules_configuration:GlobalCollection

--- a/entry_points.txt
+++ b/entry_points.txt
@@ -8,4 +8,3 @@ mta = mta.scripting.cli:cli
 [mta.application_collections]
 base = mta.entities:BaseWebUICollection
 projects = mta.entities.projects:ProjectCollection
-globalconfigurations = mta.entities.rules_configuration:GlobalCollection

--- a/mta/entities/analysis_results.py
+++ b/mta/entities/analysis_results.py
@@ -73,6 +73,8 @@ class AnalysisDeleteView(View):
 class AnalysisDetailsView(BaseLoggedInPage):
     """This view represents details page of specific analysis"""
 
+    title = Text(".//h1")
+
     transformation_path = Card('.//article[./div[(.)="Transformation path"]]')
     status = Card('.//article[./div[(.)="Status"]]')
 
@@ -81,6 +83,10 @@ class AnalysisDetailsView(BaseLoggedInPage):
     custom_rules = Card('.//article[./div[(.)="Custom rules"]]')
     custom_labels = Card('.//article[./div[(.)="Custom labels"]]')
     advanced_options = Card('.//article[./div[(.)="Advanced options"]]')
+
+    @property
+    def is_displayed(self):
+        return "Analysis" in self.title.text and self.transformation_path.is_displayed
 
 
 class AnalysisResults(Updateable, NavigatableMixin):

--- a/mta/entities/global_configuration.py
+++ b/mta/entities/global_configuration.py
@@ -1,4 +1,3 @@
-import attr
 from taretto.navigate import NavigateToAttribute
 from taretto.navigate import NavigateToSibling
 from widgetastic.utils import WaitFillViewStrategy
@@ -10,17 +9,20 @@ from widgetastic_patternfly4 import Pagination
 from widgetastic_patternfly4.table import Table
 
 from mta.base.application.implementations.web_ui import MTANavigateStep
+from mta.base.application.implementations.web_ui import NavigatableMixin
 from mta.base.application.implementations.web_ui import navigate_to
 from mta.base.application.implementations.web_ui import ViaWebUI
-from mta.base.modeling import BaseCollection
 from mta.entities import BaseLoggedInPage
 from mta.utils import conf
 from mta.utils.ftp import FTPClientWrapper
+from mta.utils.update import Updateable
 from mta.widgetastic import DropdownMenu
 from mta.widgetastic import HiddenFileInput
 from mta.widgetastic import Input
 from mta.widgetastic import MTACheckboxSelect
 from mta.widgetastic import MTATab
+
+# All Global Rule's views
 
 
 class SystemRulesView(BaseLoggedInPage):
@@ -47,19 +49,9 @@ class SystemRulesView(BaseLoggedInPage):
 
     clear = Text('.//button[contains(text(), "Clear all filters")]')
 
-    def clear_filters(self):
-        if self.clear.is_displayed:
-            self.clear.click()
-
-    def search(self, search_value, filter_type="Source", clear_filters=False):
-        """Fill input box with 'search_value', use 'filter_type' to choose filter selector.
-        If no filter_type is entered then the default for page is used.
-        """
-        if clear_filters:
-            self.clear_filters()
-        if filter_type:
-            self.filter_type_selector.item_select(filter_type)
-        self.filter_by.item_select(search_value)
+    @property
+    def is_displayed(self):
+        return self.table.is_displayed and self.show_all_rules.is_displayed
 
 
 class DeleteCustomRuleView(View):
@@ -87,46 +79,15 @@ class CustomRulesView(BaseLoggedInPage):
             4: Dropdown(),
         },
     )
+    upload_rule = HiddenFileInput(locator='.//input[contains(@accept,".xml")]')
+    close_button = Button("Close")
+    fill_strategy = WaitFillViewStrategy("15s")
+
     delete_rules = View.nested(DeleteCustomRuleView)
 
     @property
     def is_displayed(self):
         return self.add_rule_button.is_displayed and self.table.is_displayed
-
-    @View.nested
-    class custom_rules(View):  # noqa
-        upload_rule = HiddenFileInput(locator='.//input[contains(@accept,".xml")]')
-        close_button = Button("Close")
-        fill_strategy = WaitFillViewStrategy("15s")
-
-        def upload_rule_file(self, value):
-            """
-            Args:
-                values: custom rule file to be uploaded
-            """
-            self.wait_displayed()
-            self.parent.add_rule_button.click()
-            # upload custom rules
-            env = conf.get_config("env")
-            fs1 = FTPClientWrapper(env.ftpserver.entities.mta)
-            file_path = fs1.download(value)
-            self.upload_rule.fill(file_path)
-            self.close_button.click()
-
-        def delete(self, file_name, cancel=False):
-            """
-            Method to delete custom rule file
-            :param file_name: file name to delete
-            """
-            for row in self.parent.table:
-                if row.read()["Short path"] == file_name:
-                    row[4].widget.item_select("Delete")
-            if cancel:
-                self.parent.delete_rules.cancel_button.click()
-            else:
-                self.parent.delete_rules.delete_button.click()
-            self.parent.wait_displayed()
-            return file_name not in [row.read()["Short path"] for row in self.parent.table]
 
 
 class RulesConfigurationView(BaseLoggedInPage):
@@ -153,8 +114,11 @@ class RulesConfigurationView(BaseLoggedInPage):
         )
 
 
+# All Global Label's views
+
+
 class SystemLabelsView(BaseLoggedInPage):
-    """This view represents System rules tab page"""
+    """This view represents System labels tab page"""
 
     paginator = Pagination(locator='.//div[contains(@class, "pf-c-pagination")]')
 
@@ -167,9 +131,9 @@ class SystemLabelsView(BaseLoggedInPage):
     )
     search = Input(locator='.//input[@aria-label="Filter by provider ID"]')
 
-    def search_project(self, provider_id):
-        view = navigate_to(self, "SystemLabel")
-        view.search.fill(provider_id)
+    @property
+    def is_displayed(self):
+        return self.table.is_displayed and self.search.is_displayed
 
 
 class DeleteCustomLabelView(View):
@@ -185,7 +149,7 @@ class DeleteCustomLabelView(View):
 
 
 class CustomLabelsView(BaseLoggedInPage):
-    """This view represents Custom rules tab page"""
+    """This view represents Custom labels tab page"""
 
     paginator = Pagination(locator='.//div[contains(@class, "pf-c-pagination")]')
     add_label_button = Button("Add label")
@@ -197,46 +161,15 @@ class CustomLabelsView(BaseLoggedInPage):
             2: Dropdown(),
         },
     )
+    upload_label = HiddenFileInput(locator='.//input[contains(@accept,".xml")]')
+    close_button = Button("Close")
+    fill_strategy = WaitFillViewStrategy("15s")
+
     delete_labels = View.nested(DeleteCustomLabelView)
 
     @property
     def is_displayed(self):
         return self.add_label_button.is_displayed and self.table.is_displayed
-
-    @View.nested
-    class custom_labels(View):  # noqa
-        upload_label = HiddenFileInput(locator='.//input[contains(@accept,".xml")]')
-        close_button = Button("Close")
-        fill_strategy = WaitFillViewStrategy("15s")
-
-        def upload_label_file(self, value):
-            """
-            Args:
-                values: custom label file to be uploaded
-            """
-            self.wait_displayed()
-            self.parent.add_label_button.click()
-            # upload custom labels
-            env = conf.get_config("env")
-            fs1 = FTPClientWrapper(env.ftpserver.entities.mta)
-            file_path = fs1.download(value)
-            self.upload_label.fill(file_path)
-            self.close_button.click()
-
-        def delete(self, file_name, cancel=False):
-            """
-            Method to delete custom label file
-            :param file_name: file name to delete
-            """
-            for row in self.parent.table:
-                if row.read()["Short path"] == file_name:
-                    row[2].widget.item_select("Delete")
-            if cancel:
-                self.parent.delete_labels.cancel_button.click()
-            else:
-                self.parent.delete_labels.delete_button.click()
-            self.parent.wait_displayed()
-            return file_name not in [row.read()["Short path"] for row in self.parent.table]
 
 
 class LabelsConfigurationView(BaseLoggedInPage):
@@ -263,12 +196,103 @@ class LabelsConfigurationView(BaseLoggedInPage):
         )
 
 
-@attr.s
-class GlobalCollection(BaseCollection):
-    pass
+class GlobalConfigurations(Updateable, NavigatableMixin):
+    """Class for representing all the global custom/system rules/labels methods/operations"""
+
+    def __init__(self, application):
+        self.application = application
+
+    def upload_custom_label_file(self, value):
+        """Method for uploading custom label file
+        Args:
+            value: custom label file to be uploaded
+        """
+        view = navigate_to(self, "CustomLabel")
+        view.wait_displayed()
+        view.add_label_button.click()
+        # upload custom labels
+        env = conf.get_config("env")
+        fs1 = FTPClientWrapper(env.ftpserver.entities.mta)
+        file_path = fs1.download(value)
+        view.upload_label.fill(file_path)
+        view.close_button.click()
+
+    def delete_custom_label_file(self, file_name, cancel=False):
+        """Method for deleting custom label file
+        :param file_name: file name to delete
+        """
+        view = navigate_to(self, "CustomLabel")
+        view.wait_displayed()
+        for row in view.table:
+            if row.read()["Short path"] == file_name:
+                row[2].widget.item_select("Delete")
+        if cancel:
+            view.delete_labels.cancel_button.click()
+        else:
+            view.delete_labels.delete_button.click()
+        view.wait_displayed()
+        return file_name not in [row.read()["Short path"] for row in view.table]
+
+    def search_system_labels(self, provider_id):
+        """Method for searching system labels"""
+        view = navigate_to(self, "SystemLabel")
+        view.search.fill(provider_id)
+
+    def upload_custom_rule_file(self, value):
+        """Method for uploading custom rule file
+        Args:
+            value: custom rule file to be uploaded
+        """
+        view = navigate_to(self, "CustomRule")
+        view.wait_displayed()
+        view.add_rule_button.click()
+        # upload custom rules
+        env = conf.get_config("env")
+        fs1 = FTPClientWrapper(env.ftpserver.entities.mta)
+        file_path = fs1.download(value)
+        view.upload_rule.fill(file_path)
+        view.close_button.click()
+
+    def delete_custom_rule(self, file_name, cancel=False):
+        """Method to delete custom rule file
+        :param file_name: file name to delete
+        """
+        view = navigate_to(self, "CustomRule")
+        view.wait_displayed()
+
+        for row in view.table:
+            if row.read()["Short path"] == file_name:
+                row[4].widget.item_select("Delete")
+        if cancel:
+            view.delete_rules.cancel_button.click()
+        else:
+            view.delete_rules.delete_button.click()
+        view.wait_displayed()
+        return file_name not in [row.read()["Short path"] for row in view.table]
+
+    def clear_filters(self):
+        """Method to clear all the system filters"""
+        view = navigate_to(self, "SystemRule")
+        view.wait_displayed()
+
+        if view.clear.is_displayed:
+            view.clear.click()
+
+    def search_system_rules(self, search_value, filter_type="Source", clear_filters=False):
+        """Fill input box with 'search_value', use 'filter_type' to choose filter selector.
+        If no filter_type is entered then the default for page is used.
+        """
+        view = navigate_to(self, "SystemRule")
+        view.wait_displayed()
+
+        if clear_filters:
+            self.clear_filters()
+        if filter_type:
+            view.filter_type_selector.item_select(filter_type)
+        view.filter_by.item_select(search_value)
 
 
-@ViaWebUI.register_destination_for(GlobalCollection, "AllRules")
+@ViaWebUI.register_destination_for(GlobalConfigurations, "AllRules")
 class AllRules(MTANavigateStep):
     VIEW = RulesConfigurationView
     prerequisite = NavigateToAttribute("application.collections.base", "LoggedIn")
@@ -277,7 +301,7 @@ class AllRules(MTANavigateStep):
         self.prerequisite_view.navigation.select("Rules configuration")
 
 
-@ViaWebUI.register_destination_for(GlobalCollection, "AllLabels")
+@ViaWebUI.register_destination_for(GlobalConfigurations, "AllLabels")
 class AllLabels(MTANavigateStep):
     VIEW = LabelsConfigurationView
     prerequisite = NavigateToAttribute("application.collections.base", "LoggedIn")
@@ -286,7 +310,7 @@ class AllLabels(MTANavigateStep):
         self.prerequisite_view.navigation.select("Labels configuration")
 
 
-@ViaWebUI.register_destination_for(GlobalCollection, "SystemRule")
+@ViaWebUI.register_destination_for(GlobalConfigurations, "SystemRule")
 class SystemRule(MTANavigateStep):
     VIEW = SystemRulesView
     prerequisite = NavigateToSibling("AllRules")
@@ -295,7 +319,7 @@ class SystemRule(MTANavigateStep):
         self.prerequisite_view.system_rules.click()
 
 
-@ViaWebUI.register_destination_for(GlobalCollection, "CustomRule")
+@ViaWebUI.register_destination_for(GlobalConfigurations, "CustomRule")
 class CustomRule(MTANavigateStep):
     VIEW = CustomRulesView
     prerequisite = NavigateToSibling("AllRules")
@@ -304,7 +328,7 @@ class CustomRule(MTANavigateStep):
         self.prerequisite_view.custom_rules.click()
 
 
-@ViaWebUI.register_destination_for(GlobalCollection, "SystemLabel")
+@ViaWebUI.register_destination_for(GlobalConfigurations, "SystemLabel")
 class SystemLabel(MTANavigateStep):
     VIEW = SystemLabelsView
     prerequisite = NavigateToSibling("AllLabels")
@@ -313,7 +337,7 @@ class SystemLabel(MTANavigateStep):
         self.prerequisite_view.system_labels.click()
 
 
-@ViaWebUI.register_destination_for(GlobalCollection, "CustomLabel")
+@ViaWebUI.register_destination_for(GlobalConfigurations, "CustomLabel")
 class CustomLabel(MTANavigateStep):
     VIEW = CustomLabelsView
     prerequisite = NavigateToSibling("AllLabels")

--- a/mta/entities/global_configuration.py
+++ b/mta/entities/global_configuration.py
@@ -10,6 +10,7 @@ from widgetastic_patternfly4 import Pagination
 from widgetastic_patternfly4.table import Table
 
 from mta.base.application.implementations.web_ui import MTANavigateStep
+from mta.base.application.implementations.web_ui import navigate_to
 from mta.base.application.implementations.web_ui import ViaWebUI
 from mta.base.modeling import BaseCollection
 from mta.entities import BaseLoggedInPage
@@ -152,13 +153,123 @@ class RulesConfigurationView(BaseLoggedInPage):
         )
 
 
+class SystemLabelsView(BaseLoggedInPage):
+    """This view represents System rules tab page"""
+
+    paginator = Pagination(locator='.//div[contains(@class, "pf-c-pagination")]')
+
+    table = Table(
+        locator='.//table[contains(@aria-label, "Table")]',
+        column_widgets={
+            "Provider ID": Button(locator='.//th[@data-label="Provider ID"]/button'),
+            2: Dropdown(),
+        },
+    )
+    search = Input(locator='.//input[@aria-label="Filter by provider ID"]')
+
+    def search_project(self, provider_id):
+        view = navigate_to(self, "SystemLabel")
+        view.search.fill(provider_id)
+
+
+class DeleteCustomLabelView(View):
+    title = Text(locator=".//h1[contains(normalize-space(.), 'Delete')]")
+    fill_strategy = WaitFillViewStrategy("35s")
+
+    delete_button = Button("Delete")
+    cancel_button = Button("Cancel")
+
+    @property
+    def is_displayed(self):
+        return self.delete_button.is_displayed
+
+
+class CustomLabelsView(BaseLoggedInPage):
+    """This view represents Custom rules tab page"""
+
+    paginator = Pagination(locator='.//div[contains(@class, "pf-c-pagination")]')
+    add_label_button = Button("Add label")
+    search = Input(locator=".//input[@aria-label='Filter by short path']")
+    table = Table(
+        locator='.//table[contains(@aria-label, "Table")]',
+        column_widgets={
+            "Short path": Button(locator='.//th[@data-label="Short path"]/button'),
+            2: Dropdown(),
+        },
+    )
+    delete_labels = View.nested(DeleteCustomLabelView)
+
+    @property
+    def is_displayed(self):
+        return self.add_label_button.is_displayed and self.table.is_displayed
+
+    @View.nested
+    class custom_labels(View):  # noqa
+        upload_label = HiddenFileInput(locator='.//input[contains(@accept,".xml")]')
+        close_button = Button("Close")
+        fill_strategy = WaitFillViewStrategy("15s")
+
+        def upload_label_file(self, value):
+            """
+            Args:
+                values: custom label file to be uploaded
+            """
+            self.wait_displayed()
+            self.parent.add_label_button.click()
+            # upload custom labels
+            env = conf.get_config("env")
+            fs1 = FTPClientWrapper(env.ftpserver.entities.mta)
+            file_path = fs1.download(value)
+            self.upload_label.fill(file_path)
+            self.close_button.click()
+
+        def delete(self, file_name, cancel=False):
+            """
+            Method to delete custom label file
+            :param file_name: file name to delete
+            """
+            for row in self.parent.table:
+                if row.read()["Short path"] == file_name:
+                    row[2].widget.item_select("Delete")
+            if cancel:
+                self.parent.delete_labels.cancel_button.click()
+            else:
+                self.parent.delete_labels.delete_button.click()
+            self.parent.wait_displayed()
+            return file_name not in [row.read()["Short path"] for row in self.parent.table]
+
+
+class LabelsConfigurationView(BaseLoggedInPage):
+    """This view is for presenting Labels configuration page"""
+
+    title = Text(locator=".//h1")
+
+    @View.nested
+    class system_labels(MTATab):  # noqa
+        TAB_NAME = "System labels"
+        including_view = View.include(SystemLabelsView, use_parent=True)
+
+    @View.nested
+    class custom_labels(MTATab):  # noqa
+        TAB_NAME = "Custom labels"
+        including_view = View.include(CustomLabelsView, use_parent=True)
+
+    @property
+    def is_displayed(self):
+        return (
+            self.title.text == "Labels configuration"
+            and self.system_labels.is_displayed
+            and self.custom_labels.is_displayed
+        )
+
+
 @attr.s
-class GlobalRulesCollection(BaseCollection):
+class GlobalCollection(BaseCollection):
     pass
 
 
-@ViaWebUI.register_destination_for(GlobalRulesCollection, "All")
-class All(MTANavigateStep):
+@ViaWebUI.register_destination_for(GlobalCollection, "AllRules")
+class AllRules(MTANavigateStep):
     VIEW = RulesConfigurationView
     prerequisite = NavigateToAttribute("application.collections.base", "LoggedIn")
 
@@ -166,19 +277,46 @@ class All(MTANavigateStep):
         self.prerequisite_view.navigation.select("Rules configuration")
 
 
-@ViaWebUI.register_destination_for(GlobalRulesCollection, "System")
-class System(MTANavigateStep):
+@ViaWebUI.register_destination_for(GlobalCollection, "AllLabels")
+class AllLabels(MTANavigateStep):
+    VIEW = LabelsConfigurationView
+    prerequisite = NavigateToAttribute("application.collections.base", "LoggedIn")
+
+    def step(self):
+        self.prerequisite_view.navigation.select("Labels configuration")
+
+
+@ViaWebUI.register_destination_for(GlobalCollection, "SystemRule")
+class SystemRule(MTANavigateStep):
     VIEW = SystemRulesView
-    prerequisite = NavigateToSibling("All")
+    prerequisite = NavigateToSibling("AllRules")
 
     def step(self):
         self.prerequisite_view.system_rules.click()
 
 
-@ViaWebUI.register_destination_for(GlobalRulesCollection, "Custom")
-class Custom(MTANavigateStep):
+@ViaWebUI.register_destination_for(GlobalCollection, "CustomRule")
+class CustomRule(MTANavigateStep):
     VIEW = CustomRulesView
-    prerequisite = NavigateToSibling("All")
+    prerequisite = NavigateToSibling("AllRules")
 
     def step(self):
         self.prerequisite_view.custom_rules.click()
+
+
+@ViaWebUI.register_destination_for(GlobalCollection, "SystemLabel")
+class SystemLabel(MTANavigateStep):
+    VIEW = SystemLabelsView
+    prerequisite = NavigateToSibling("AllLabels")
+
+    def step(self):
+        self.prerequisite_view.system_labels.click()
+
+
+@ViaWebUI.register_destination_for(GlobalCollection, "CustomLabel")
+class CustomLabel(MTANavigateStep):
+    VIEW = CustomLabelsView
+    prerequisite = NavigateToSibling("AllLabels")
+
+    def step(self):
+        self.prerequisite_view.custom_labels.click()

--- a/mta/tests/test_global_labels.py
+++ b/mta/tests/test_global_labels.py
@@ -1,0 +1,188 @@
+import fauxfactory
+import pytest
+
+from mta.base.application.implementations.web_ui import navigate_to
+from mta.entities.analysis_results import AnalysisResults
+
+
+@pytest.fixture(scope="function")
+def add_global_custom_label(application):
+    """This fixture with upload global custom label file"""
+    file_name = "customWebLogic.windup.label.xml"
+    view = navigate_to(application.collections.globalconfigurations, "CustomLabel")
+    view.custom_labels.upload_label_file(file_name)
+    view.table.wait_displayed("20s")
+    return file_name
+
+
+def test_crud_global_custom_label(application):
+    """ Test to upload global custom labels file
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/12h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        casecomponent: WebConsole
+        testSteps:
+            1. Login to MTA web console
+            2. Navigate to Global > Rules configuration > Custom Labels
+            3. Click on Add label button and browse label file
+            4. Click on Close button
+        expectedResults:
+            1. Custom label file should be listed in table
+    """
+    file_name = "customWebLogic.windup.label.xml"
+    view = navigate_to(application.collections.globalconfigurations, "CustomLabel")
+    view.custom_labels.upload_label_file(file_name)
+    view.table.wait_displayed("20s")
+    assert file_name in [label["Short path"] for label in view.table.read()]
+    assert view.custom_labels.delete(file_name)
+
+
+def test_search_global_custom_label(application, request):
+    """ Test to search global custom labels file from table
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/12h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        casecomponent: WebConsole
+        testSteps:
+            1. Login to MTA web console
+            2. Navigate to Global > Labels configuration > Custom labels
+            3. Click on Add label button and browse labels files
+            4. Click on Close button
+            5. Add value in 'Filter by short path' input box and hit enter
+        expectedResults:
+            1. Custom labels file should searched by substring
+    """
+    file_name = "customWebLogic.windup.label.xml"
+    view = navigate_to(application.collections.globalconfigurations, "CustomLabel")
+    view.custom_labels.upload_label_file(file_name)
+    view.table.wait_displayed("20s")
+    view.search.fill("custom")
+
+    @request.addfinalizer
+    def _finalize():
+        view.search.fill("")
+        view.custom_labels.delete(file_name)
+
+    assert file_name in [label["Short path"] for label in view.table.read()]
+    view.search.fill("custom-invalid")
+    try:
+        assert file_name not in [label["Short path"] for label in view.table.read()]
+    except IndexError:
+        pass
+
+
+def test_analysis_global_custom_label(application, request, add_global_custom_label):
+    """ Test to upload global custom labels file
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/12h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        casecomponent: WebConsole
+        testSteps:
+            1. Upload global custom labels file
+            2. Create project and run analysis
+            3. Go to analysis details page and check if custom labels contains global scope custom
+               label file
+        expectedResults:
+            1. Analysis should be completed successfully
+    """
+    file_name = add_global_custom_label
+    project = application.collections.projects.create(
+        name=fauxfactory.gen_alphanumeric(12, start="project_"),
+        description=fauxfactory.gen_alphanumeric(start="desc_"),
+        app_list=["acmeair-webapp-1.0-SNAPSHOT.war"],
+    )
+    assert project.exists
+    request.addfinalizer(project.delete_if_exists)
+    analysis_results = AnalysisResults(application, project.name)
+    view = navigate_to(analysis_results, "AnalysisDetailsPage")
+    view.custom_labels.wait_displayed("30s")
+    card_info = view.custom_labels.read()
+    assert file_name in card_info["body"].split("Global")[1]
+
+
+def test_invalid_label_file_type(application, request):
+    """ Test to upload global custom label file
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/12h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        casecomponent: WebConsole
+        testSteps:
+            1. Upload invalid global custom label file
+            2. Check number of labels in it
+        expectedResults:
+            1. Invalid global custom label file should have 0 labels
+    """
+    file_name = "custom.Test1rules.rhamt.xml"
+    view = navigate_to(application.collections.globalconfigurations, "CustomLabel")
+    view.custom_labels.upload_label_file(file_name)
+    view.table.wait_displayed("20s")
+
+    @request.addfinalizer
+    def _finalize():
+        view.search.fill("")
+        view.custom_labels.delete(file_name)
+
+    all_labels = view.table.read()
+    for label in all_labels:
+        if label["Short path"] == file_name:
+            assert int(label["Number of labels"]) == 0
+
+
+def test_total_global_system_label(application):
+    """ Test to upload global custom label file
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/12h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        casecomponent: WebConsole
+        testSteps:
+            1. Navigate to Global > Labels configuration > System labels
+            2. Check show all labels
+        expectedResults:
+            1. Total system labels count should be equal or greater than 1
+    """
+    view = navigate_to(application.collections.globalconfigurations, "SystemLabel")
+    view.wait_displayed()
+    assert view.paginator.total_items >= 1
+
+
+def test_search_global_system_label(application):
+    """ Test to upload global custom label file
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/12h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        casecomponent: WebConsole
+        testSteps:
+            1. Navigate to Global > Labels configuration > System labels
+            2. Search by label's provider ID
+        expectedResults:
+            1. It should list label with that provider ID
+    """
+    view = navigate_to(application.collections.globalconfigurations, "SystemLabel")
+    view.search.wait_displayed("30s")
+    view.search.fill("core")
+    data = view.table.read()[0]
+    assert data["Provider ID"] == "core_labels"

--- a/mta/widgetastic/__init__.py
+++ b/mta/widgetastic/__init__.py
@@ -273,4 +273,4 @@ class Card(View):
 
     @property
     def is_displayed(self):
-        return self.body.is_displayed
+        return self.header.is_displayed


### PR DESCRIPTION
 Automated global labels configuration test cases  
  - test_crud_global_custom_label
  - test_search_global_custom_label
  - test_analysis_global_custom_label
  - test_invalid_label_file_type
  - test_total_global_system_label
  - test_search_global_system_label

Created common collection for both label and rules configurations
  - Collection added - GlobalCollection
  - Added global_configuration.py file
  - This file contains all views and navigations regitration for rules and labels

- Updated rules test cases as per this collection

Signed-off-by: Ganesh Hubale <ghubale@redhat.com>